### PR TITLE
1539 Kth Missing Positive Number

### DIFF
--- a/leetcode/1539_kth_missing_positive_number.py
+++ b/leetcode/1539_kth_missing_positive_number.py
@@ -1,0 +1,26 @@
+"""
+    1539. Kth Missing Positive Number
+"""
+
+from typing import List
+
+def find_kth_positive(arr: List[int], k: int) -> int:
+    """
+        Finds the kth missing positive number that is not included in arr
+    """
+    if len(arr) == 0:
+        return k
+
+    expecting = 1
+    missing = 0
+    for i, num in range(len(arr)):
+        diff = num - expecting
+        if missing + diff >= k:
+            if i == 0:
+                return k
+
+            return arr[i - 1] + (k - missing)
+
+        missing += diff
+        expecting = num + 1
+    return arr[-1] + (k - missing)


### PR DESCRIPTION
https://www.loom.com/share/e1fff4c047a04e44a9704301dc28e792?sid=0e5fe7a4-f56d-4e8a-b945-2006ddcdc5eb
https://leetcode.com/problems/kth-missing-positive-number/

Find the kth positive number missing from the give list that contains only positive numbers and is in increasing order.

Example:
[1, 3, 4]
The missing positive numbers are [2, 5, 6...]
If k is 1 then the result is 2
If k is 2 then the result is 6