### PR TITLE
636. Exclusive time of Functions

### DIFF
--- a/leetcode/636_exclusive_time_of_functions.py
+++ b/leetcode/636_exclusive_time_of_functions.py
@@ -1,0 +1,33 @@
+"636. Exclusive Time of Functions"
+
+from typing import List
+
+def parse_log(log):
+    "Parse logs"
+    sections = log.split(':')
+    return (int(sections[0]), sections[1], int(sections[2]))
+
+def exclusive_times(n: int, logs: List[str]) -> List[int]:
+    "636. Exclusive Time of Functions"
+    times = [0] * n
+    stack = []
+    prev_time = 0
+
+    for log in logs:
+        log_id, action, time = parse_log(log)
+
+        if "start" == action:
+            if stack:
+                diff = time - prev_time
+                times[stack[-1]] += diff
+
+            stack.append(log_id)
+            prev_time = time
+        else:
+            stack.pop()
+
+            times[log_id] += time - prev_time + 1
+
+            prev_time = time + 1
+
+    return times


### PR DESCRIPTION
https://www.loom.com/share/09667725fe024d459a52564e5430fd08?sid=713d6033-3813-4bb7-a5cf-bc868feb4c34

Given a list of logs formatted "function_id:start:time"  or "function_id:end:time" find the amount of time each function ran for. If a function calls another one, possibly recursively, the time for the callee should stop until the called function ends.